### PR TITLE
Add null-check to Binance disconnect

### DIFF
--- a/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
+++ b/xchange-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingExchange.java
@@ -48,7 +48,14 @@ public class BinanceStreamingExchange extends BinanceExchange implements Streami
         BinanceStreamingService service = streamingService;
         streamingService = null;
         streamingMarketDataService = null;
-        return service.disconnect();
+        
+        Completable completable;
+        if (service != null) {
+            completable = service.disconnect();
+        } else {
+            completable = Completable.complete();
+        }
+        return completable;
     }
 
     @Override


### PR DESCRIPTION
I'm getting a NPE at `service.disconnect()` sometimes, which would not occur with this. Maybe there should be a log message or some other type of notificiation instead of just returning `Completable.complete()` though.